### PR TITLE
Performance improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ packages
 pubspec.lock
 .idea
 test/type_factories_gen.dart
-test/main.dart.js
-test/main.dart.js.deps
-test/main.dart.js.map
-test/main.dart.precompiled.js
+test/main.dart.*
+test/benchmark.dart.*
+

--- a/lib/dynamic_injector.dart
+++ b/lib/dynamic_injector.dart
@@ -58,13 +58,8 @@ class DynamicInjector implements Injector {
   Set<Type> get types {
     var types = new Set.from(_types);
     var parent = this.parent;
-    while (parent != null) {
-      for(var type in parent._types) {
-        if (!types.contains(type)) {
-          types.add(type);
-        }
-      }
-      parent = parent.parent;
+    for (var parent = this.parent; parent != null; parent = parent.parent) {
+      types.addAll(parent._types);
     }
     return types;
   }

--- a/lib/static_injector.dart
+++ b/lib/static_injector.dart
@@ -63,13 +63,8 @@ class StaticInjector implements Injector {
   Set<Type> get types {
     var types = new Set.from(_types);
     var parent = this.parent;
-    while (parent != null) {
-      for(var type in parent._types) {
-        if (!types.contains(type)) {
-          types.add(type);
-        }
-      }
-      parent = parent.parent;
+    for (var parent = this.parent; parent != null; parent = parent.parent) {
+      types.addAll(parent._types);
     }
     return types;
   }

--- a/run-benchmark.sh
+++ b/run-benchmark.sh
@@ -1,0 +1,11 @@
+#!/bin/sh -v
+set -e
+
+# run tests in dart
+dart test/benchmark.dart
+
+# run dart2js on tests
+dart2js test/benchmark.dart -o test/benchmark.dart.js
+
+# run tests in node
+node test/benchmark.dart.js

--- a/test/benchmark.dart
+++ b/test/benchmark.dart
@@ -1,0 +1,31 @@
+library di.bench;
+
+import 'package:di/di.dart';
+import 'package:di/dynamic_injector.dart';
+import 'package:di/annotations.dart';
+import 'package:benchmark_harness/benchmark_harness.dart';
+
+class ClassA {}
+class ClassB {}
+class ClassC {}
+
+var parent = new DynamicInjector(modules: [new Module()..type(ClassA)]);
+var child = parent.createChild([new Module()..type(ClassB)]);
+var grandChild = child.createChild([new Module()..type(ClassC)]);
+
+class InjectorTypesBench extends BenchmarkBase {
+  const InjectorTypesBench() : super("InjectorTypesBench");
+
+  static void main() {
+    new InjectorTypesBench().report();
+  }
+
+  // The benchmark code.
+  void run() {
+    var l = grandChild.types.length;
+  }
+}
+
+main() {
+  InjectorTypesBench.main();
+}


### PR DESCRIPTION
See the commit comments for explanations.

The deeper the injector hierarchy the greater the gain !

For this to work, `_types` should remain unchanged (we assume parents `_types` will not change after `_registerBindings` has been called - which is the case now). Then what do you think of turning `_types` into an immutable set, the code would then break if someone try to modify the `_types` after they have been initialized.

I can take care of this in a further commit if you agree.
