### PR TITLE
Prefixing mirrors.dart library name with 'di'.

### DIFF
--- a/lib/mirrors.dart
+++ b/lib/mirrors.dart
@@ -1,4 +1,4 @@
-library mirrors;
+library di.mirrors;
 
 import 'dart:mirrors';
 export 'dart:mirrors';


### PR DESCRIPTION
The rest of the libs in this use the 'di.' prefix- it's a bit odd that this one was just 'mirrors'.
