### PR TITLE
On Windows, possible RangeException due to os-specific file separator

### DIFF
--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -295,9 +295,11 @@ class CrawlerVisitor {
         newImport = systemImport; // original uri
       } else {
         // relative import
-        String import = currentFile.entryPointImport.
-            substring(0, currentFile.entryPointImport.lastIndexOf('/'));
+        String import = currentFile.entryPointImport;
+        import = import.replaceAll('\\', '/'); // if at all needed, on Windows
+        import = import.substring(0, import.lastIndexOf('/'));
         var currentDir = new File(currentFile.canonicalPath).parent.path;
+        currentDir = currentDir.replaceAll('\\', '/'); // if at all needed, on Windows
         if (uri.startsWith('../')) {
           while (uri.startsWith('../')) {
             uri = uri.substring('../'.length);


### PR DESCRIPTION
While running angular.dart.tutorial Chapter_07 generator step (https://github.com/angular/angular.dart.tutorial/tree/master/Chapter_07), I ran into this issue, not sure if this is specific to my environment; but doing the above changes fixed the issue. Without this change, was running into RangeException running the generator in Dart Editor, Windows Command line, or, cygwin, or, Git shell (even though, the later two indeed have file separator as '/').
