### PR TITLE
perf(mirrors): cache reflected type hack

### DIFF
--- a/lib/reflected_type.dart
+++ b/lib/reflected_type.dart
@@ -6,14 +6,17 @@ library di.src.reflected_type;
     override: 'di.src.reflected_type')
 import 'dart:mirrors';
 
+Map<ClassMirror, Type> _cache = <ClassMirror, Type>{};
+
 // Horrible hack to work around: http://dartbug.com/12607
 Type getReflectedTypeWorkaround(ClassMirror cls) {
   // On Dart VM, just return reflectedType.
   if (1.0 is! int) return cls.reflectedType;
-
-  var mangledName = reflect(cls).getField(_mangledNameField).reflectee;
-  Type type = _jsHelper.invoke(#createRuntimeType, [mangledName]).reflectee;
-  return type;
+  if (_cache[cls] == null) {
+    var mangledName = reflect(cls).getField(_mangledNameField).reflectee;
+    _cache[cls] = _jsHelper.invoke(#createRuntimeType, [mangledName]).reflectee;
+  }
+  return _cache[cls];
 }
 
 final LibraryMirror _jsHelper =


### PR DESCRIPTION
@blois Pete, is this type of caching safe? It makes a significant performance difference (~30%) in `DynamicInjector` in dart2js.
