### PR TITLE
Adding test for support of parameterized types

### DIFF
--- a/test/main.dart
+++ b/test/main.dart
@@ -113,7 +113,7 @@ class ParameterizedType<T> {
   ParameterizedType();
 }
 
-@Injectable
+@Injectable()
 class ParameterizedDependency {
   ParameterizedType<bool> _p;
   ParameterizedDependency(this._p);
@@ -175,8 +175,9 @@ createInjectorSpec(String injectorName, InjectorFactory injectorFactory) {
 
 
     it('should resolve parameterized types', () {
+      var value = new ParameterizedType<bool>();
       var injector = injectorFactory([new Module()
-            ..value(ParameterizedType, new ParameterizedType<bool>())
+            ..value(value.runtimeType, value)
             ..type(ParameterizedDependency)
       ]);
       expect(injector.get(ParameterizedDependency), instanceOf(ParameterizedDependency));


### PR DESCRIPTION
Currently this works with the DynamicInjector but not with the StaticInjector.

Registration is really ugly since this is a syntax error in Dart:
    ..value(ParameterizedType<bool>, ...);

Does not work with the static injector as that generates code looking for ParameterizedType and not ParameterizedType<bool>. Because of the syntax error mentioned earlier, I'm not sure the best way to do this.

Note that this appears to have been working before https://github.com/angular/di.dart/commit/13c9925500b168713ef7e3dc4f892aae3a3df63d
