### PR TITLE
Untyped Constructor parameter should output proper error (fix #41)

### DIFF
--- a/lib/dynamic_injector.dart
+++ b/lib/dynamic_injector.dart
@@ -32,6 +32,10 @@ class DynamicInjector extends Injector {
 
     resolveArgument(int pos) {
       ParameterMirror p = ctor.parameters[pos];
+      if (MirrorSystem.getName(p.type.qualifiedName) == 'dynamic') {
+        var name = MirrorSystem.getName(p.simpleName);
+        throw new NoProviderError(error("The '$name' parameter must be typed"));
+      }
       if (p.type is TypedefMirror) {
         throw new NoProviderError(
             error('Cannot create new instance of a typedef ${p.type}'));

--- a/test/main.dart
+++ b/test/main.dart
@@ -32,12 +32,12 @@ class Injectable {
 // just some classes for testing
 @Injectable()
 class Engine {
-  String id = 'v8-id';
+  final String id = 'v8-id';
 }
 
 @Injectable()
 class MockEngine implements Engine {
-  String id = 'mock-id';
+  final String id = 'mock-id';
 }
 
 @Injectable()
@@ -51,6 +51,13 @@ class Car {
   Injector injector;
 
   Car(this.engine, this.injector);
+}
+
+class Lemon {
+  final engine;
+  final Injector injector;
+
+  Lemon(this.engine, this.injector);
 }
 
 class NumDependency {
@@ -89,9 +96,7 @@ int compareIntAsc(int a, int b) => b.compareTo(a);
 class WithTypeDefDependency {
   CompareInt compare;
 
-  WithTypeDefDependency(CompareInt c) {
-    compare = c;
-  }
+  WithTypeDefDependency(this.compare);
 }
 
 class MultipleConstructors {
@@ -116,13 +121,13 @@ class ParameterizedType<T1, T2> {
 
 @Injectable()
 class ParameterizedDependency {
-  ParameterizedType<bool, int> _p;
+  final ParameterizedType<bool, int> _p;
   ParameterizedDependency(this._p);
 }
 
 @Injectable()
 class GenericParameterizedDependency {
-  ParameterizedType _p;
+  final ParameterizedType _p;
   GenericParameterizedDependency(this._p);
 }
 
@@ -147,6 +152,8 @@ void main() {
   createInjectorSpec('StaticInjector',
       (modules, [name]) => new StaticInjector(modules: modules, name: name,
           typeFactories: type_factories_gen.typeFactories));
+
+  dynamicInjectorTest();
 }
 
 typedef Injector InjectorFactory(List<Module> modules, [String name]);
@@ -471,7 +478,6 @@ createInjectorSpec(String injectorName, InjectorFactory injectorFactory) {
       expect(injector.get(Log).log.join(' '), 'ClassOne');
     });
 
-
     describe('creation strategy', () {
 
       it('should get called for instance creation', () {
@@ -549,4 +555,19 @@ createInjectorSpec(String injectorName, InjectorFactory injectorFactory) {
 
   });
 
+}
+
+void dynamicInjectorTest() {
+  describe('untyped argument', () {
+
+    it('should display a comprehensible error message', () {
+      var module = new Module()..type(Lemon)..type(Engine);
+      var injector = new DynamicInjector(modules : [module]);
+
+      expect(() {
+        injector.get(Lemon);
+      }, toThrow(NoProviderError, "The 'engine' parameter must be typed "
+          "(resolving Lemon)"));
+    });
+  });
 }


### PR DESCRIPTION
A few remarks:
- I should refactor the tests from my recent PRs for those that are applicable to the dynamic injector only. It would be better to create an other test files,
- The checks are currently done when the type is instantiated, I think they should be implemented in the `Module` 

If you agree, the better might be to merge all my recent PRs and then I'll rework all the code in a PR next week ? (I'll then create a new issue to track the progress)
