### PR TITLE
[WIP] Allow inject annotations on constructors (fix #42)

### DIFF
--- a/test/main.dart
+++ b/test/main.dart
@@ -49,11 +49,12 @@ class HiddenConstructor {
   HiddenConstructor._();
 }
 
-@Injectable()
+
 class Car {
   Engine engine;
   Injector injector;
 
+  @Injectable()
   Car(this.engine, this.injector);
 }
 


### PR DESCRIPTION
This is a **WIP** which should eventually allow:
- using annotations on constructors,
- using `@inject` annotations.

The second part should be trivial after the first is implemented.

I see two effects of putting an annotation on a constructor:
- The containing class should be marked as injectable (done in [the third commit](https://github.com/vicb/di.dart/commit/a50d20704297e59b3c04c885cce0c2d04347ef29))
- The constructor argument should also be marked as injectable (**todo**)

@blois @pavelgj I would appreciate your feedback on this description & the third commit (which is pretty small). Thanks.
