### PR TITLE
Moving Analyzer to v0.11

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ homepage: https://github.com/angular/di.dart
 environment:
   sdk: '>=0.8.10'
 dependencies:
-  analyzer: '>=0.10.0 <0.11.0'
+  analyzer: '>=0.11.0 <0.12.0'
 dev_dependencies:
   benchmark_harness: any
   unittest: any


### PR DESCRIPTION
This primarily has a number of API additions for things such as walking all libraries, visiting all compilation units, finding types, etc. Easier to work with for the generator.

Note that Angular has the version constrained to <0.11 as well, will have a PR for that as well.

(Note that the core issue is that the minor version rev'ed when it should not have).
