### PR TITLE
Some follow-up tweaks from initial transformers

### DIFF
--- a/lib/transformer/injector_generator.dart
+++ b/lib/transformer/injector_generator.dart
@@ -353,10 +353,6 @@ library ${id.package}.$libPath.generated_static_injector;
 import 'package:di/di.dart';
 import 'package:di/static_injector.dart';
 
-@MirrorsUsed(override: const [
-    'di.dynamic_injector',
-    'mirrors'])
-import 'dart:mirrors' show MirrorsUsed;
 ''');
 }
 
@@ -367,9 +363,6 @@ Injector createStaticInjector({List<Module> modules, String name,
   new StaticInjector(modules: modules, name: name,
       allowImplicitInjection: allowImplicitInjection,
       typeFactories: factories);
-
-Module get staticInjectorModule => new Module()
-    ..value(Injector, createStaticInjector(name: 'Static Injector'));
 
 final Map<Type, TypeFactory> factories = <Type, TypeFactory>{
 ''');

--- a/lib/transformer/refactor.dart
+++ b/lib/transformer/refactor.dart
@@ -28,8 +28,9 @@ void transformIdentifiers(Transform transform, Resolver resolver,
   }
 
   if (identifierElement == null) {
-    transform.logger.info('Unable to resolve $identifier, not '
-        'transforming entry point.');
+    // TODO(blois) enable once on barback 0.12.0
+    // transform.logger.fine('Unable to resolve $identifier, not '
+    //     'transforming entry point.');
     transform.addOutput(transform.primaryInput);
     return;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
   sdk: '>=0.8.10'
 dependencies:
   analyzer: '>=0.12.0 <0.13.0'
+  barback: '>=0.11.1 <0.12.0'
   code_transformers: '>=0.0.1-dev.2 <0.1.0'
   path: ">=0.9.0 <2.0.0"
 dev_dependencies:

--- a/test/injector_generator_spec.dart
+++ b/test/injector_generator_spec.dart
@@ -426,7 +426,7 @@ main() {
             generators: [
               'import_0.Engine: (f) => new import_0.Engine(),',
               'import_0.Car: (f) => new import_0.Car(),',
-            ]).then((_) {
+            ]).whenComplete(() {
               injectableAnnotations.clear();
             });
       });
@@ -596,11 +596,11 @@ main() {
                   '''
             },
             imports: [
-            "import 'package:a/a.dart' as import_0;",
+              "import 'package:a/a.dart' as import_0;",
             ],
             generators: [
-               'import_0.Engine: (f) => new import_0.Engine(),',
-               'import_0.Car: (f) => new import_0.Car(f(import_0.Engine, import_0.Turbo)),',
+              'import_0.Engine: (f) => new import_0.Engine(),',
+              'import_0.Car: (f) => new import_0.Car(f(import_0.Engine, import_0.Turbo)),',
             ]);
       });
   });
@@ -633,11 +633,7 @@ library a.web.main.generated_static_injector;
 
 import 'package:di/di.dart';
 import 'package:di/static_injector.dart';
-
-@MirrorsUsed(override: const [
-    'di.dynamic_injector',
-    'mirrors'])
-import 'dart:mirrors' show MirrorsUsed;''';
+''';
 
 const String BOILER_PLATE = '''
 Injector createStaticInjector({List<Module> modules, String name,
@@ -645,9 +641,6 @@ Injector createStaticInjector({List<Module> modules, String name,
   new StaticInjector(modules: modules, name: name,
       allowImplicitInjection: allowImplicitInjection,
       typeFactories: factories);
-
-Module get staticInjectorModule => new Module()
-    ..value(Injector, createStaticInjector(name: 'Static Injector'));
 
 final Map<Type, TypeFactory> factories = <Type, TypeFactory>{''';
 


### PR DESCRIPTION
- Suppressed info message when compiling without using auto_injector, to eliminate unnecessary messages when compiling with Angular. Will switch to logging level fine which is not emitted by default once this moves to barback 0.12.
- Removed the @MirrorsUsed statement- ideal scenario is that mirrors are not encountered at all in which case this should not be there. Now that Angular is moving towards no mirrors, this gets in the way.
- Removed the generated injector module- I don't think this serves a purpose.
- Added explicit barback dependency.
