### PR TITLE
feat(generator): Add optional flag to preserve comments

### DIFF
--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -254,13 +254,14 @@ class SourceCrawler {
 
   SourceCrawler(this.sdkPath, this.packageRoots);
 
-  void crawl(String entryPoint, CompilationUnitCrawler _visitor) {
+  void crawl(String entryPoint, CompilationUnitCrawler _visitor,
+             {bool preserveComments : false}) {
     JavaSystemIO.setProperty("com.google.dart.sdk", sdkPath);
     DartSdk sdk = DirectoryBasedDartSdk.defaultSdk;
 
     AnalysisOptionsImpl contextOptions = new AnalysisOptionsImpl();
     contextOptions.cacheSize = 256;
-    contextOptions.preserveComments = false;
+    contextOptions.preserveComments = preserveComments;
     contextOptions.analyzeFunctionBodies = false;
     context.analysisOptions = contextOptions;
     sdk.context.analysisOptions = contextOptions;


### PR DESCRIPTION
Add ability for generators to preserve doc comments when parsing source code.

Closes: #74
