### PR TITLE
Entry point updates to transformer & updating to latest Analyzer

### DIFF
--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -269,7 +269,7 @@ class SourceCrawler {
     var packageUriResolver =
         new PackageUriResolver(packageRoots.map(
             (pr) => new JavaFile.fromUri(new Uri.file(pr))).toList());
-    context.sourceFactory = new SourceFactory.con2([
+    context.sourceFactory = new SourceFactory([
       new DartUriResolver(sdk),
       new FileUriResolver(),
       packageUriResolver
@@ -287,10 +287,9 @@ class SourceCrawler {
       entryPointImport = entryPointFile.getAbsolutePath();
     }
 
-    Source source = new FileBasedSource.con1(
-        context.sourceFactory.contentCache, entryPointFile);
+    Source source = new FileBasedSource.con1(entryPointFile);
     ChangeSet changeSet = new ChangeSet();
-    changeSet.added(source);
+    changeSet.addedSource(source);
     context.applyChanges(changeSet);
     LibraryElement rootLib = context.computeLibraryElement(source);
     CompilationUnit resolvedUnit =

--- a/lib/transformer.dart
+++ b/lib/transformer.dart
@@ -83,7 +83,6 @@ TransformOptions _parseSettings(Map args) {
   }
 
   return new TransformOptions(
-      dartEntries: _readStringListValue(args, 'dart_entries'),
       injectableAnnotations: annotations,
       injectedTypes: injectedTypes,
       sdkDirectory: sdkDir);

--- a/lib/transformer/injector_generator.dart
+++ b/lib/transformer/injector_generator.dart
@@ -21,8 +21,7 @@ class InjectorGenerator extends Transformer with ResolverTransformer {
     this.resolvers = resolvers;
   }
 
-  Future<bool> isPrimary(Asset input) =>
-      new Future.value(options.isDartEntry(input.id));
+  Future<bool> isPrimary(Asset input) => options.isDartEntry(input);
 
   applyResolver(Transform transform, Resolver resolver) =>
       new _Processor(transform, resolver, options).process();
@@ -326,7 +325,7 @@ class _Processor {
 
     var outputBuffer = new StringBuffer();
 
-    _writeStaticInjectorHeader(resolver.entryPoint, outputBuffer);
+    _writeStaticInjectorHeader(transform.primaryInput.id, outputBuffer);
     usedLibs.forEach((lib) {
       if (lib.isDartCore) return;
       var uri = resolver.getImportUri(lib, from: _generatedAssetId);
@@ -346,9 +345,10 @@ class _Processor {
 }
 
 void _writeStaticInjectorHeader(AssetId id, StringSink sink) {
-  var libPath = path.withoutExtension(id.path).replaceAll('/', '.');
+  var libName = path.withoutExtension(id.path).replaceAll('/', '.');
+  libName = libName.replaceAll('-', '_');
   sink.write('''
-library ${id.package}.$libPath.generated_static_injector;
+library ${id.package}.$libName.generated_static_injector;
 
 import 'package:di/di.dart';
 import 'package:di/static_injector.dart';

--- a/lib/transformer/options.dart
+++ b/lib/transformer/options.dart
@@ -1,16 +1,20 @@
 library di.transformer.options;
 
+import 'dart:async';
+
 import 'package:barback/barback.dart';
+import 'package:code_transformers/resolver.dart';
+
+/// Returns either a bool or a Future<bool> when complete.
+typedef EntryFilter(Asset asset);
 
 /** Options used by DI transformers */
 class TransformOptions {
 
   /**
-   * The file path of the primary Dart entry point (main) for the application.
-   * This is used as the starting point to find all injectable types used by the
-   * application.
+   * Filter to determine which assets should be modified.
    */
-  final Set<String> dartEntries;
+  final EntryFilter entryFilter;
 
   /**
    * List of additional annotations which are used to indicate types as being
@@ -28,9 +32,9 @@ class TransformOptions {
    */
   final String sdkDirectory;
 
-  TransformOptions({List<String> dartEntries, String sdkDirectory,
+  TransformOptions({EntryFilter entryFilter, String sdkDirectory,
       List<String> injectableAnnotations, List<String> injectedTypes})
-    : dartEntries = dartEntries.toSet(),
+    : entryFilter = entryFilter != null ? entryFilter : isPossibleDartEntry,
       sdkDirectory = sdkDirectory,
       injectableAnnotations =
           injectableAnnotations != null ? injectableAnnotations : [],
@@ -40,6 +44,5 @@ class TransformOptions {
       throw new ArgumentError('sdkDirectory must be provided.');
   }
 
-  // Don't need to check package as transformers only run for primary package.
-  bool isDartEntry(AssetId id) => dartEntries.contains(id.path);
+  Future<bool> isDartEntry(Asset asset) => new Future.value(entryFilter(asset));
 }

--- a/lib/transformer/refactor.dart
+++ b/lib/transformer/refactor.dart
@@ -35,7 +35,7 @@ void transformIdentifiers(Transform transform, Resolver resolver,
     return;
   }
 
-  var lib = resolver.entryLibrary;
+  var lib = resolver.getLibrary(transform.primaryInput.id);
   var transaction = resolver.createTextEditTransaction(lib);
   var unit = lib.definingCompilationUnit.node;
 
@@ -89,7 +89,7 @@ void _addImport(TextEditTransaction transaction, CompilationUnit unit,
 
 /// Vistior which changes every reference to a resolved element to a specific
 /// string value.
-class _IdentifierTransformer extends GeneralizingASTVisitor {
+class _IdentifierTransformer extends GeneralizingAstVisitor {
   final TextEditTransaction transaction;
   /// The element which all references to should be replaced.
   final Element original;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,9 +8,9 @@ homepage: https://github.com/angular/di.dart
 environment:
   sdk: '>=0.8.10'
 dependencies:
-  analyzer: '>=0.12.0 <0.13.0'
+  analyzer: '>=0.13.0 <0.14.0'
   barback: '>=0.11.1 <0.12.0'
-  code_transformers: '>=0.0.1-dev.2 <0.1.0'
+  code_transformers: '>=0.0.1 <0.1.0'
   path: ">=0.9.0 <2.0.0"
 dev_dependencies:
   benchmark_harness: any
@@ -19,5 +19,8 @@ dev_dependencies:
 
 transformers:
 - di:
-    dart_entries: test/auto_injector_test.dart
     injectable_annotations: di.tests.Injectable
+
+dependency_overrides:
+  code_transformers: 0.0.1-dev.3
+  analyzer: '>=0.13.0-dev <0.14.0'


### PR DESCRIPTION
- Removes the explicit list of entry points and switches to auto-detecting entry points, following the standard pub build model.
- Updating to latest code_transformers which has the entry point detection code.
- Updating to latest Analyzer (code_transformers dependency)
- Updating transformer tests to include the main(), also took the chance to remove unnecessary files in the tests now that we can generate injectors for types within web/.
