### PR TITLE
Updating to work on Dart 1.4.0-dev.2

### DIFF
--- a/lib/transformer/injector_generator.dart
+++ b/lib/transformer/injector_generator.dart
@@ -21,7 +21,7 @@ class InjectorGenerator extends Transformer with ResolverTransformer {
     this.resolvers = resolvers;
   }
 
-  Future<bool> isPrimary(Asset input) => options.isDartEntry(input);
+  Future<bool> shouldApplyResolver(Asset asset) => options.isDartEntry(asset);
 
   applyResolver(Transform transform, Resolver resolver) =>
       new _Processor(transform, resolver, options).process();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   sdk: '>=0.8.10'
 dependencies:
   analyzer: '>=0.13.0 <0.14.0'
-  barback: '>=0.11.1 <0.12.0'
-  code_transformers: '>=0.1.0 <0.2.0'
+  barback: '>=0.11.1 <0.14.0'
+  code_transformers: '>=0.1.3 <0.2.0'
   path: ">=0.9.0 <2.0.0"
 dev_dependencies:
   benchmark_harness: any


### PR DESCRIPTION
Pub in 1.4 is requiring barback 0.13 which has a breaking change in isPrimary (see https://codereview.chromium.org//223553008). This change allows DI to target either barback 0.11.1+ or 0.13.0, depending on pub version.

End result is that this allows DI to work on both stable and dev channel of Dart.
