### PR TITLE
perf(injector): +29%. Use an array for type lookup instead of a map.

### DIFF
--- a/lib/key.dart
+++ b/lib/key.dart
@@ -1,15 +1,22 @@
 part of di;
 
+int _uniqKey = 0;
+Map<int, int> hashToKey = {};
+
 class Key {
   final Type type;
   final Type annotation;
+  int hashCode;
+  int key;
 
-  const Key(this.type, [this.annotation]);
+  Key(this.type, [this.annotation]) {
+    hashCode = type.hashCode + annotation.hashCode;
+    key = hashToKey.putIfAbsent(hashCode, () => _uniqKey++);
+  }
 
   bool operator ==(other) =>
-      other is Key && other.type == type && other.annotation == annotation;
+      other is Key && other.hashCode == hashCode;
 
-  int get hashCode => type.hashCode + annotation.hashCode;
 
   String toString() {
     String asString = type.toString();


### PR DESCRIPTION
The array is much faster, but we are trading memory for speed:
  Each injector will create a O(# of registered types) sized array.
  This is probably the right decision, but we should watch large
  apps.

This speeds up directive creation in AngularDart by 29%
