### PR TITLE
fix(transformer): Exception on parameterized types with implicit constructors

### DIFF
--- a/lib/transformer/injector_generator.dart
+++ b/lib/transformer/injector_generator.dart
@@ -252,11 +252,11 @@ class _Processor {
     }
     if (resolver.getImportUri(cls.library, from: _generatedAssetId) == null) {
       _warn('${cls.name} cannot be injected because '
-          'the containing file cannot be imported.', ctor);
+          'the containing file cannot be imported.', cls);
       return false;
     }
     if (!cls.typeParameters.isEmpty) {
-      _warn('${cls.name} is a parameterized type.', ctor);
+      _warn('${cls.name} is a parameterized type.', cls);
       // Only warn.
     }
     if (ctor.name != '') {

--- a/test/injector_generator_spec.dart
+++ b/test/injector_generator_spec.dart
@@ -79,7 +79,7 @@ main() {
           ],
           messages: [
             'warning: Parameterized is a parameterized type. '
-            '(package:a/a.dart 2 18)',
+            '(package:a/a.dart 1 16)',
           ]);
     });
 


### PR DESCRIPTION
Fixing a transformer crash which was occurring when attempting to warn about parameterized
types when the type has an implicit constructor. Issue was that the constructor is not backed by a node in this case.
