### PR TITLE
fix(circular deps): Improve error messages

### DIFF
--- a/lib/src/base_injector.dart
+++ b/lib/src/base_injector.dart
@@ -79,7 +79,7 @@ abstract class BaseInjector implements Injector, ObjectFactory {
     assert(_checkKeyConditions(key, resolving));
 
     // Do not bother checking the array until we are fairly deep.
-    if (resolving.depth > 30 && resolving.ancestorKeys().contains(key)) {
+    if (resolving.depth > 30 && resolving.ancestorKeys.contains(key)) {
       throw new CircularDependencyError(
           error(resolving, 'Cannot resolve a circular dependency!', key));
     }
@@ -224,7 +224,7 @@ class ResolutionContext {
 
   /// Returns the [key]s of the ancestors of this node (including this node) in
   /// the order that ascends the tree.  Note that [ROOT] has no [key].
-  List<Key> ancestorKeys() {
+  List<Key> get ancestorKeys {
     var keys = [];
     for (var node = this; node.parent != null; node = node.parent) {
       keys.add(node.key);

--- a/lib/src/error_helper.dart
+++ b/lib/src/error_helper.dart
@@ -16,6 +16,15 @@ String error(ResolutionContext resolving, String message, [Key appendDependency]
   if (appendDependency != null) {
     resolving = new ResolutionContext(resolving.depth + 1, appendDependency, resolving);
   }
-  String path = resolving.ancestorKeys().reversed.join(' -> ');
-  return '$message (resolving $path)';
+  List resolvingKeys = resolving.ancestorKeys.reversed.toList(growable: false);
+  // De-duplicate keys when there is a circular dependency
+  // This is required because we don't check for circular dependencies before the
+  // a depth threshold which would lead to msg like "A -> B -> A -> B -> ... -> A"
+  for (var i = 1; i < resolvingKeys.length - 1; i++) {
+    if (resolvingKeys[i] == resolvingKeys.first) {
+      resolvingKeys = resolvingKeys.sublist(0, i + 1);
+    }
+  }
+
+  return '$message (resolving ${resolvingKeys.join(" -> ")})';
 }

--- a/lib/src/injector.dart
+++ b/lib/src/injector.dart
@@ -71,7 +71,7 @@ abstract class Injector {
    *
    * Thus, if a descendant D of the child requests an instance for K, the child
    * will mask any binding for K made by a proper ancestor injector, provided
-   * that P's visbility reveals the child's binding to D.
+   * that P's visibility reveals the child's binding to D.
    * For example, if the child has no proper descendant and P's visibility
    * deems that the child is visible to the child itself, then the first
    * request for the child to get an instance for K will trigger the creation of

--- a/test/main.dart
+++ b/test/main.dart
@@ -448,7 +448,7 @@ createInjectorSpec(String injectorName, InjectorFactory injectorFactory) {
       expect(() {
         injector.get(CircularA);
       }, toThrow(CircularDependencyError, 'Cannot resolve a circular '
-          'dependency! (resolving CircularA -> CircularB -> CircularA'));
+          'dependency! (resolving CircularA -> CircularB -> CircularA)'));
     });
 
     it('should throw an exception when circular dependency in factory', () {
@@ -459,7 +459,7 @@ createInjectorSpec(String injectorName, InjectorFactory injectorFactory) {
       expect(() {
         injector.get(CircularA);
       }, toThrow(CircularDependencyError, 'Cannot resolve a '
-          'circular dependency! (resolving CircularA -> CircularA'));
+          'circular dependency! (resolving CircularA -> CircularA)'));
     });
 
 


### PR DESCRIPTION
As we don't check for circular dependencies before a given depth
threshold is reached we had messages like:

```
"A -> B -> A -> B -> A -> ... -> A"
```

This commit implements a deduplication to have only:

```
"A -> B -> A"
```
