### PR TITLE
feat(dynamic injector): enforce annotations with dynamic injector

### DIFF
--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -11,3 +11,7 @@ class NoProviderError extends ArgumentError {
 class CircularDependencyError extends ArgumentError {
   CircularDependencyError(message) : super(message);
 }
+
+class NoAnnotationError extends ArgumentError {
+  NoAnnotationError(message) : super (message);
+}

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -144,7 +144,7 @@ class Module {
    * * [visibility]: Function which determines fi the requesting injector can
    *   see the type in the current injector.
    */
-  @Deprecated("Use bind(type, implementedBy: impl)")
+  @Deprecated("Use bind(type, toImplementation: impl)")
   void type(Type type, {Type withAnnotation, Type implementedBy, Visibility visibility}) {
     bind(type, withAnnotation: withAnnotation, visibility: visibility,
         toImplementation: implementedBy);

--- a/lib/static_injector.dart
+++ b/lib/static_injector.dart
@@ -26,7 +26,7 @@ class StaticInjector extends BaseInjector {
     this.typeFactories = _extractTypeFactories(modules);
   }
 
-  newFromParent(List<Module> modules, String name) =>
+  Injector newFromParent(List<Module> modules, String name) =>
       new StaticInjector._fromParent(modules, this, name: name);
 
   Object newInstanceOf(Type type, ObjectFactory objFactory,


### PR DESCRIPTION
closes #58

Enforcing annotations on types injected via TypeProvider is a good
practice to make sure that the code will not break when switching from a
dynamic to a static injector.
