### PR TITLE
chore(travis): curl should follow links to download Dart

### DIFF
--- a/scripts/travis/setup.sh
+++ b/scripts/travis/setup.sh
@@ -15,7 +15,7 @@ CHANNEL=`echo $JOB | cut -f 2 -d -`
 echo Fetch Dart channel: $CHANNEL
 
 echo http://storage.googleapis.com/dart-archive/channels/$CHANNEL/release/latest/sdk/$DART_SDK_ZIP
-curl http://storage.googleapis.com/dart-archive/channels/$CHANNEL/release/latest/sdk/$DART_SDK_ZIP > $DART_SDK_ZIP
+curl -L http://storage.googleapis.com/dart-archive/channels/$CHANNEL/release/latest/sdk/$DART_SDK_ZIP > $DART_SDK_ZIP
 echo Fetched new dart version $(unzip -p $DART_SDK_ZIP dart-sdk/version)
 rm -rf dart-sdk
 unzip $DART_SDK_ZIP > /dev/null


### PR DESCRIPTION
@pavelgj this is required to fix travis as the link is now a redirect
