### PR TITLE
perf(injector): inlined getProviderWithInjector

### DIFF
--- a/benchmark/injector_benchmark_common.dart
+++ b/benchmark/injector_benchmark_common.dart
@@ -30,8 +30,7 @@ class InjectorBenchmark extends BenchmarkBase {
       ..type(D)
       ..type(E)
       ..type(E, withAnnotation: AnnTwo, implementedBy: ETwo )
-      ..type(F)
-      ..type(G);
+      ..type(F);
   }
 
   teardown() {

--- a/benchmark/instance_benchmark.dart
+++ b/benchmark/instance_benchmark.dart
@@ -6,8 +6,17 @@ import 'injector_benchmark_common.dart';
 class InstanceBenchmark extends InjectorBenchmark{
   InstanceBenchmark(name, injectorFactory) : super(name, injectorFactory);
 
+  StaticInjector injector;
+
+  void setup(){
+    super.setup();
+    injector = injectorFactory([module]);
+    for (var i = 0; i < 20; i++) {
+      injector = injector.createChild(null);
+    }
+  }
+
   void run(){
-    Injector injector = injectorFactory([module]);
     for (var i = 0; i < 30; i++) {
       injector.get(A);
     }

--- a/lib/src/base_injector.dart
+++ b/lib/src/base_injector.dart
@@ -97,9 +97,23 @@ abstract class BaseInjector implements Injector, ObjectFactory {
           error(resolving, 'Cannot resolve a circular dependency!', key));
     }
 
-    var providerWithInjector = _getProviderWithInjectorForKey(key, resolving);
-    var provider = providerWithInjector.provider;
-    var injector = providerWithInjector.injector;
+    // This code is pasted in createChildWithResolvingHistory for performance
+    var provider = key.id < _providers.length ? _providers[key.id] : null;
+    var injector = this;
+    while (provider == null){
+      if (injector.parent == null){
+        if (allowImplicitInjection) {
+          provider = new TypeProvider(key.type);
+          break;
+        }
+        throw new NoProviderError(
+            error(resolving, 'No provider found for ${key}!', key));
+      }
+      injector = injector.parent;
+      provider = key.id < injector._providers.length ?
+                  injector._providers[key.id] : null;
+    }
+
     var visible = provider.visibility == null ||
         provider.visibility(requester, injector);
 
@@ -118,8 +132,7 @@ abstract class BaseInjector implements Injector, ObjectFactory {
           throw new NoProviderError(
               error(resolving, 'No provider found for ${key}!', key));
         }
-        injector = injector.parent
-            ._getProviderWithInjectorForKey(key, resolving).injector;
+        injector = injector.parent;
       }
       return injector.getInstanceByKey(key, requester, resolving);
     }
@@ -129,41 +142,11 @@ abstract class BaseInjector implements Injector, ObjectFactory {
 
     // cache the value.
     if (allowImplicitInjection == true) {
-      providerWithInjector.injector._instancesMap[key.id] = value;
+      injector._instancesMap[key.id] = value;
     } else {
-      providerWithInjector.injector._instancesList[key.id] = value;
+      injector._instancesList[key.id] = value;
     }
     return value;
-  }
-
-  /**
-   * Finds the nearest ancestor injector that binds a [Provider] to [key] and
-   * returns that [Provider] and its binding [Injector].  If there is no such
-   * [Injector], then
-   *
-   * - if [allowImplicitInjection] is true for the root injector (not this
-   *   injector), returns a default [Provider] and the root injector.
-   * - if [allowImplicitInjector] is false for the root injector, throws
-   *   [NoProviderError].
-   *
-   * [resolving] is only used for error reporting.
-   */
-  _ProviderWithInjector _getProviderWithInjectorForKey(
-      Key key, ResolutionContext resolving) {
-    if (key.id < _providers.length) {
-      var provider = _providers[key.id];
-      if (provider != null) {
-        return new _ProviderWithInjector(provider, this);
-      }
-    }
-    if (parent != null) {
-      return parent._getProviderWithInjectorForKey(key, resolving);
-    }
-    if (allowImplicitInjection) {
-      return new _ProviderWithInjector(new TypeProvider(key.type), this);
-    }
-    throw new NoProviderError(
-        error(resolving, 'No provider found for ${key}!', key));
   }
 
   bool _checkKeyConditions(Key key, ResolutionContext resolving) {
@@ -202,9 +185,24 @@ abstract class BaseInjector implements Injector, ObjectFactory {
         } else if (key is! Key) {
           throw 'forceNewInstances must be List<Key|Type>';
         }
-        var providerWithInjector =
-            _getProviderWithInjectorForKey(key, resolving);
-        var provider = providerWithInjector.provider;
+
+        // This code is pasted from getInstanceByKey for performance
+        var provider = key.id < _providers.length ? _providers[key.id] : null;
+        var injector = this;
+        while (provider == null){
+          if (injector.parent == null){
+            if (allowImplicitInjection) {
+              provider = new TypeProvider(key.type);
+              break;
+            }
+            throw new NoProviderError(
+                error(resolving, 'No provider found for ${key}!', key));
+          }
+          injector = injector.parent;
+          provider = key.id < injector._providers.length ?
+                     injector._providers[key.id] : null;
+        }
+
         forceNew.bindByKey(key,
             toFactory: (Injector inj) =>
                 provider.get(this, inj, inj as ObjectFactory, resolving),
@@ -222,12 +220,6 @@ abstract class BaseInjector implements Injector, ObjectFactory {
 
   Object newInstanceOf(Type type, ObjectFactory factory, Injector requestor,
                        ResolutionContext resolving);
-}
-
-class _ProviderWithInjector {
-  final Provider provider;
-  final BaseInjector injector;
-  _ProviderWithInjector(this.provider, this.injector);
 }
 
 /**


### PR DESCRIPTION
Removed `_getProviderWithInjectorForKey`. The code is now inlined in two places that used it. Results in ~40% speedup in dart VM with `instance_benchmark.dart` testing `getInstance` speed of deeply nested injectors.

Improvements are from:
- Function inlining
- Using iteration to walk up injector tree instead of recursion
- Removing creation of wrapper class used to return multiple values

Having redundant code was chosen over using a function that returns only an injector, since after such a function returns, the caller would need to retrieve the provider again. 

The call on line 102 of `base_injector.dart` was removed as the recursive call would result in a walk up the injector tree in the next function anyway.
