### PR TITLE
perf(injector): edited fromParent constructor module config copying

### DIFF
--- a/benchmark/injector_create_child_benchmark.dart
+++ b/benchmark/injector_create_child_benchmark.dart
@@ -1,0 +1,47 @@
+import 'package:di/static_injector.dart';
+
+import 'injector_benchmark_common.dart';
+
+class CreateChildBenchmark extends InjectorBenchmark{
+  CreateChildBenchmark(name, injectorFactory) : super(name, injectorFactory);
+
+  StaticInjector injector;
+  List moreModules;
+
+  void setup() {
+    getModule([_]) {
+      var m = new Module()
+        ..bind(A)
+        ..bind(B)
+        ..bind(C)
+        ..bind(D)
+        ..bind(E)
+        ..bind(F)
+        ..bind(G);
+      return m;
+    }
+    module = getModule();
+    moreModules = new List.generate(30, getModule, growable:true);
+  }
+
+  void run(){
+    injector = injectorFactory([module]);
+    for (var i = 0; i < 30; i++) {
+      injector = injector.createChild(moreModules);
+    }
+  }
+}
+
+main() {
+  var typeFactories = {
+      A: (f) => new A(f(B), f(C)),
+      B: (f) => new B(f(D), f(E)),
+      C: (f) => new C(),
+      D: (f) => new D(),
+      E: (f) => new E(),
+  };
+
+  new CreateChildBenchmark('CreateChildBenchmark',
+      (m) => new StaticInjector(modules: m, typeFactories: typeFactories)
+  ).report();
+}

--- a/lib/src/base_injector.dart
+++ b/lib/src/base_injector.dart
@@ -67,9 +67,7 @@ abstract class BaseInjector implements Injector, ObjectFactory {
     }
     if (modules != null) {
       modules.forEach((module) {
-        module.bindings.forEach((k, v) {
-          _providers[k] = v;
-        });
+        module.updateListWithBindings(_providers);
       });
     }
     _providers[injectorId] = new ValueProvider(Injector, this);

--- a/test/main.dart
+++ b/test/main.dart
@@ -735,9 +735,25 @@ void dynamicInjectorTest() {
     it('should get an instance using implicit injection for an unseen type', (){
       var module = new Module()
           ..bind(Engine);
-      var injector = new DynamicInjector(modules: [module], allowImplicitInjection: true);
+      var injector =
+          new DynamicInjector(modules: [module], allowImplicitInjection: true);
 
-      expect(injector.get(SpecialEngine).id, equals('special-id'));
+      expect(injector.get(SpecialEngine).id).toEqual('special-id');
+    });
+
+    it('should give higher precedence to bindings in parent module', () {
+      var module = new Module()
+          ..bind(Engine);
+      var child = new Module()
+          ..bind(Engine, toImplementation:TurboEngine);
+      var injector = new DynamicInjector(modules: [child]);
+      module.install(child);
+      injector = new DynamicInjector(modules: [module]);
+      var id = injector.get(Engine).id;
+      expect(id).toEqual('v8-id');
+      injector = new DynamicInjector(modules: [child]);
+      id = injector.get(Engine).id;
+      expect(id).toEqual('turbo-engine-id');
     });
 
   });


### PR DESCRIPTION
Updated fromParent constructor to pass providers list to module to update instead of having module constructing a temporary map. 10-15% faster on create child benchmark.

Module providers are no longer cached which could mean worse performance for deep module trees, but since Angular never has child modules more than one deep this should not be a problem. A cache can be added later if necessary. 
