### PR TITLE
Dynamic reflector minor fix & code/test cleanup

### DIFF
--- a/lib/di.dart
+++ b/lib/di.dart
@@ -4,5 +4,5 @@ export 'key.dart' show Key, key;
 export 'src/injector.dart' show Injector, ModuleInjector;
 export 'src/module.dart' show Module, Binding, DEFAULT_VALUE;
 export 'src/reflector.dart' show TypeReflector;
-export 'src/errors.dart' hide BaseError;
+export 'src/errors.dart' hide BaseError, PRIMITIVE_TYPES;
 export 'annotations.dart';

--- a/lib/module_transformer.dart
+++ b/lib/module_transformer.dart
@@ -1,4 +1,4 @@
-library di.transformer.export_transformer;
+library di.transformer.module_transformer;
 
 import 'dart:async';
 import 'package:barback/barback.dart';

--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -8,6 +8,11 @@ abstract class BaseError extends Error {
   String toString() => message;
 }
 
+final List<Key> PRIMITIVE_TYPES = <Key>[
+    new Key(num), new Key(int), new Key(double), new Key(String),
+    new Key(bool), new Key(dynamic)
+];
+
 class DynamicReflectorError extends BaseError {
   DynamicReflectorError(message) : super(message);
 }
@@ -35,14 +40,9 @@ abstract class ResolvingError extends Error {
 class NoProviderError extends ResolvingError {
   NoProviderError(key): super(key);
 
-  static final List<Key> _PRIMITIVE_TYPES = <Key>[
-      new Key(num), new Key(int), new Key(double), new Key(String),
-      new Key(bool)
-  ];
-
   String toString(){
     var root = keys.first;
-    if (_PRIMITIVE_TYPES.contains(root)) {
+    if (PRIMITIVE_TYPES.contains(root)) {
       return "Cannot inject a primitive type of $root! $resolveChain";
     }
     return "No provider found for $root! $resolveChain";
@@ -58,5 +58,5 @@ class NoGeneratedTypeFactoryError extends BaseError {
   NoGeneratedTypeFactoryError(Type type): super(type.toString());
   String toString() =>
       "Type '$message' not found in generated typeFactory maps. Is the type's "
-      "constructor annotated for injection?";
+      "constructor injectable and annotated for injection?";
 }

--- a/lib/src/injector.dart
+++ b/lib/src/injector.dart
@@ -37,7 +37,8 @@ abstract class Injector {
       getByKey(new Key(type, annotation));
 
   /**
-   * Faster version of [get].
+   * Faster version of [get] by saving key creation time. Should be used instead if
+   * a key instance is already available.
    */
   dynamic getByKey(Key key);
 

--- a/lib/src/reflector_dynamic.dart
+++ b/lib/src/reflector_dynamic.dart
@@ -202,7 +202,12 @@ class DynamicTypeFactories extends TypeReflector {
             "'${p.type}' can have only zero on one annotation, but it has "
             "'${p.metadata}'.");
       }
-      var pType = (p.type as ClassMirror).reflectedType;
+      ClassMirror pTypeMirror = (p.type as ClassMirror);
+      var pType = pTypeMirror.reflectedType;
+      if (pTypeMirror.typeArguments.where((m) => m.qualifiedName != #dynamic).isNotEmpty) {
+        throw new DynamicReflectorError("$pType cannot be injected because it is parameterized "
+            "with non-generic types.");
+      }
       var annotationType = p.metadata.isNotEmpty ? p.metadata.first.type.reflectedType : null;
       return new Key(pType, annotationType);
     }, growable:false);

--- a/run-benchmarks.sh
+++ b/run-benchmarks.sh
@@ -7,6 +7,7 @@ static_injector_benchmark.dart
 instance_benchmark.dart
 large_benchmark.dart"
 
+mkdir -p benchmark/generated_files
 dart scripts/class_gen.dart
 
 # run tests in dart

--- a/test_tf_gen.sh
+++ b/test_tf_gen.sh
@@ -8,5 +8,5 @@ fi
 
 set -v
 
-dart bin/generator.dart $DART_SDK test/main.dart di.tests.InjectableTest test/type_factories_gen.dart packages/
+dart --checked bin/generator.dart $DART_SDK test/main.dart di.tests.InjectableTest test/type_factories_gen.dart packages/
 


### PR DESCRIPTION
throws about parameterized types at bind time instead
added tests
consistent whitespace in tests
