### PR TITLE
chore(run-tests): execute the script with bash rather than sh

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 echo "Running generator..."


### PR DESCRIPTION
[[ ]] tests are bash specific

An error is generated when running the script with `sh`.
