### PR TITLE
Fix semver, release 2.0.3, 2.1.0, 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 3.0.0
+
+## Breaking Changes
+
+- **annotations:** Users must now explicitly import `di/annotations.dart` to use `@Injectable`
+- Supports newer versions of barback, code transformers, and analyzer
+
 # 2.1.0
 
 ## Features

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: di
-version: 2.1.0
+version: 3.0.0
 authors:
 - Vojta Jina <vojta.jina@gmail.com>
 - Pavel Jbanov <pavelgj@gmail.com>


### PR DESCRIPTION
fixes #167

fix the semver issue:
- 2.0.3 revert all breaking changes (==2.0.1),
- 2.1.0 add the new feature (typedef inject),
- 3.0.0 add the breaking changes, export & new packages - as those packages have BC, they should be updated in a Major release.

@antingshen @mhevery waiting for your approval before merging this & applying the tags. _(I don't think I can upload this to pub)_

Note: all the 3 releases have been tested.
