### PR TITLE
perf(Binding): saves a call to `reflector.parameterKeysFor()`

### DIFF
--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -58,8 +58,15 @@ class Binding {
         throw "inject must be Keys or Types. '$t' is not an instance of Key or Type.";
       }).toList(growable: false);
     } else {
-      var implementationType = toImplementation == null ? key.type : toImplementation;
-      parameterKeys = reflector.parameterKeysFor(implementationType);
+      var implementationType;
+      if (toImplementation == null) {
+        implementationType = key.type;
+        parameterKeys = reflector.parameterKeysFor(implementationType);
+      } else {
+        implementationType = toImplementation;
+        assert(reflector.parameterKeysFor(implementationType).isEmpty);
+        parameterKeys = const [];
+      }
       factory = reflector.factoryFor(implementationType);
     }
   }


### PR DESCRIPTION
When toImplementation is specified, the class is instantiated via the
`new` operator and then the ctor must have no arguments. Then there is
no need to call `parameterKeysFor` as it will always return an empty
list.

@mhevery or @antingshen could you please review this PR.
