### PR TITLE
fix: Handle classes with multiple annotations

### DIFF
--- a/lib/transformer/injector_generator.dart
+++ b/lib/transformer/injector_generator.dart
@@ -188,7 +188,7 @@ class _Processor {
         return true;
       } else if (meta.element is ConstructorElement) {
         DartType metaType = meta.element.enclosingElement.type;
-        return injectableTypes.any((DartType t) => metaType.isSubtypeOf(t));
+        if (injectableTypes.any((DartType t) => metaType.isSubtypeOf(t))) return true;
       }
     }
     return false;

--- a/test/main.dart
+++ b/test/main.dart
@@ -45,6 +45,7 @@ class InjectableTest {
 }
 
 // just some classes for testing
+@Deprecated("I'm here because of https://github.com/angular/di.dart/issues/191")
 @InjectableTest()
 class Engine {
   final String id = 'v8-id';


### PR DESCRIPTION
fixes #191

Previously the class would only be marked as injectable if the first
annotation is one of the injectable annotation. After the fix, it is
marked as injectable if any of annotaion is injectable.

The fix has been validated by 
- checking that the `FooBar` type factory is generated in the original angular.dart issue
- checking that it works by adding a `@Deprecated` annotation in the example
